### PR TITLE
chore: bump pnpm/action-setup to v5, docker/login-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         options: --health-cmd "redis-cli ping" --health-interval 5s
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v5
       - run: pnpm audit --audit-level=high
       - uses: zricethezav/gitleaks-action@b6c5bf4c5c0b50bfadfdce0cd388ec84e7100b3a # v2.3.7
       - uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # v0.31.0


### PR DESCRIPTION
## Summary
- Bump `pnpm/action-setup` from v3 to v5 across all workflows (ci, security, release)
- Bump `docker/login-action` from v3 to v4 in docker workflow
- Applies changes from Dependabot PRs #3 and #7 that had merge conflicts

## Test plan
- [ ] CI workflows run successfully with new action versions