### PR TITLE
chore: improve GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,57 +1,114 @@
 name: Bug Report
-description: Report a bug in Model Translator
+description: Something isn't working as expected
 title: "[Bug]: "
 labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to report a bug.
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+        **Before submitting**, please search [existing issues](https://github.com/Work90210/model-translator/issues) to avoid duplicates.
+
   - type: textarea
     id: description
     attributes:
       label: Describe the bug
-      description: A clear description of what the bug is.
+      description: A clear and concise description of what the bug is.
+      placeholder: When I try to import a spec from URL, the page shows a 500 error...
     validations:
       required: true
+
   - type: textarea
     id: reproduction
     attributes:
       label: Steps to reproduce
-      description: Steps to reproduce the behavior.
+      description: Minimal steps to reproduce the behavior.
       placeholder: |
-        1. Go to '...'
-        2. Click on '...'
-        3. See error
+        1. Navigate to /specs/new
+        2. Paste URL: https://petstore3.swagger.io/api/v3/openapi.json
+        3. Click "Import"
+        4. See error
     validations:
       required: true
+
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
-      description: What you expected to happen.
+      description: What you expected to happen instead.
     validations:
       required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages, screenshots, or logs if available.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of Model Translator is affected?
+      options:
+        - Transformer (npm library)
+        - Web App (Dashboard / API)
+        - Runtime (MCP server / SSE)
+        - Documentation
+        - Docker / Self-hosting
+        - CI/CD
+        - Other
+    validations:
+      required: true
+
   - type: dropdown
     id: deployment
     attributes:
       label: Deployment type
       options:
-        - Self-hosted (Docker)
+        - Hosted (cloud)
+        - Self-hosted (Docker Compose)
         - Self-hosted (manual)
-        - Development (local)
+        - Local development
     validations:
       required: true
+
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Node version, OS, browser, etc.
+      description: Any relevant version or platform info.
       placeholder: |
-        Node: v20.x
-        OS: Ubuntu 22.04
-        Browser: Chrome 120
+        Node: v20.11.0
+        OS: macOS 14.3 / Ubuntu 22.04
+        Browser: Chrome 122
+        Docker: 25.0.3
+        Model Translator version: v0.1.0
+      render: shell
+
   - type: textarea
     id: logs
     attributes:
       label: Relevant log output
+      description: Paste any relevant logs. This will be formatted as code automatically.
       render: shell
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: OpenAPI spec (if applicable)
+      description: If the bug involves a specific spec, paste a minimal reproduction or link to it.
+      render: yaml
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+        - label: I can reproduce this bug with the latest version
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/Work90210/model-translator/security/advisories/new
+    about: Report a security vulnerability via GitHub Security Advisories. Do NOT open a public issue.
+  - name: Questions & Discussions
+    url: https://github.com/Work90210/model-translator/discussions
+    about: Ask questions, share ideas, or get help from the community.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,53 @@
+name: Documentation Issue
+description: Report incorrect, missing, or unclear documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve our documentation. Whether it's a typo, missing guide, or unclear explanation — we want to know.
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of issue
+      options:
+        - Incorrect information
+        - Missing documentation
+        - Unclear or confusing
+        - Outdated content
+        - Typo or formatting
+        - Broken link
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Page or section
+      description: Link to the page or describe where the issue is.
+      placeholder: https://... or "Self-Hosting Guide > TLS Setup"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's wrong or missing? What would be better?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: If you know what the correct content should be, share it here.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to submit a PR to fix this

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,39 +1,74 @@
 name: Feature Request
-description: Suggest a feature for Model Translator
+description: Suggest a new feature or improvement
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for suggesting a feature.
+      value: |
+        Thanks for suggesting a feature! Please fill out the sections below so we can evaluate and prioritize it.
+
+        **Before submitting**, please search [existing issues](https://github.com/Work90210/model-translator/issues?q=label%3Aenhancement) and [discussions](https://github.com/Work90210/model-translator/discussions) to avoid duplicates.
+
   - type: textarea
     id: problem
     attributes:
       label: Problem statement
-      description: What problem does this feature solve?
+      description: What problem does this feature solve? What's the use case?
+      placeholder: I'm always frustrated when I have to manually...
     validations:
       required: true
+
   - type: textarea
     id: solution
     attributes:
       label: Proposed solution
-      description: Describe the solution you'd like.
+      description: Describe the solution you'd like. Be as specific as possible.
     validations:
       required: true
+
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Any alternative solutions or features you've considered.
+      description: Any alternative solutions, workarounds, or features you've considered.
+
   - type: dropdown
-    id: scope
+    id: component
     attributes:
-      label: Scope
+      label: Component
+      description: Which part of Model Translator does this affect?
       options:
-        - Transformer (MIT library)
-        - Web UI
-        - Runtime (MCP server)
-        - Infrastructure
+        - Transformer (npm library)
+        - Web App (Dashboard / API)
+        - Runtime (MCP server / SSE)
         - Documentation
+        - Docker / Self-hosting
+        - CLI
+        - Other
     validations:
       required: true
+
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How important is this feature to you?
+      options:
+        - Nice to have
+        - Important — I can work around it
+        - Critical — blocking my use case
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context, mockups, screenshots, or examples.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to submit a PR for this feature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,43 @@
 ## Summary
 
-<!-- Brief description of changes -->
+<!-- What does this PR do? Keep it brief — 1-3 sentences. -->
 
-## Changes
+## Related Issues
 
--
+<!-- Link related issues: "Closes #123", "Fixes #456", "Part of #789" -->
 
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Infrastructure / CI change
+- [ ] Breaking change (fix or feature that causes existing functionality to change)
+- [ ] Refactor (no functional changes)
+- [ ] Documentation
+- [ ] Infrastructure / CI
+- [ ] Dependencies
 
-## Checklist
+## Changes
 
-- [ ] My code follows the project's code style
-- [ ] I have performed a self-review of my own code
-- [ ] I have added tests that prove my fix is effective or my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] I have made corresponding changes to the documentation (if applicable)
+<!-- Bullet list of what changed and why. -->
+
+-
+
+## Screenshots / Recordings
+
+<!-- If applicable, add screenshots or screen recordings of the change. -->
 
 ## Test Plan
 
-<!-- How should reviewers test these changes? -->
+<!-- How should this be tested? List specific steps or scenarios. -->
 
 - [ ]
+
+## Checklist
+
+- [ ] Code follows the project's style guidelines
+- [ ] Self-reviewed — no debug logs, commented-out code, or TODOs left behind
+- [ ] Tests added/updated that prove the fix or feature works
+- [ ] All tests pass locally (`pnpm test`)
+- [ ] Lint and typecheck pass (`pnpm lint && pnpm typecheck`)
+- [ ] Documentation updated (if applicable)
+- [ ] No secrets, credentials, or sensitive data included


### PR DESCRIPTION
## Summary
Upgrade all GitHub issue and PR templates to be more professional and comprehensive.

## Changes
- **Bug report**: Added component selector, OpenAPI spec field, environment details, duplicate checklist
- **Feature request**: Added importance level, component selector, contribution checkbox
- **Documentation issue**: New template for reporting docs problems (incorrect, missing, unclear)
- **Issue config**: Disabled blank issues, added security advisory and discussions links
- **PR template**: Added related issues section, type of change checkboxes, screenshots section, expanded checklist

## Test plan
- [ ] Navigate to repo > Issues > New Issue — verify all 3 templates appear
- [ ] Verify blank issues are disabled and contact links show
- [ ] Create a PR and verify template loads