### PR TITLE
fix: correct GitHub repo name in changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "kylefuhri/model-translator" }
+    { "repo": "Work90210/model-translator" }
   ],
   "commit": false,
   "fixed": [],


### PR DESCRIPTION
The changeset changelog generator was referencing `kylefuhri/model-translator` instead of `Work90210/model-translator`, causing the release workflow to fail.