### PR TITLE
ci: switch to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,7 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Create GitHub Releases
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` from release workflow — no more npm tokens needed
- npm Trusted Publisher configured: `Work90210/model-translator` → `release.yml`
- All future publishes authenticated via GitHub Actions OIDC with provenance signatures
- Zero long-lived secrets for npm publishing

## Test plan
- [x] npm Trusted Publisher connection verified on npmjs.com
- [x] `id-token: write` permission already in workflow
- [x] `NPM_CONFIG_PROVENANCE: true` already set
- [ ] Next version bump PR will test the full automated publish flow