### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL scheme check

### DIFF
--- a/e2e/tests/landing/navigation.spec.ts
+++ b/e2e/tests/landing/navigation.spec.ts
@@ -102,7 +102,13 @@ test.describe("Landing Page Navigation @landing", () => {
 
     for (let i = 0; i < count; i++) {
       const href = await links.nth(i).getAttribute("href");
-      if (!href || href === "#" || href.startsWith("javascript:")) {
+      if (
+        !href ||
+        href === "#" ||
+        href.startsWith("javascript:") ||
+        href.startsWith("data:") ||
+        href.startsWith("vbscript:")
+      ) {
         const text = await links.nth(i).textContent();
         invalidLinks.push(`"${text?.trim()}" -> "${href}"`);
       }


### PR DESCRIPTION
Potential fix for [https://github.com/Work90210/APIFold/security/code-scanning/3](https://github.com/Work90210/APIFold/security/code-scanning/3)

In general, the problem is fixed by extending the URL scheme check so that it treats `data:` and `vbscript:` schemes as invalid in the same way as `javascript:`. This keeps the test’s semantics (“flag unsafe/invalid hrefs”) while covering all common executable URL schemes that can hide script execution.

Concretely, in `e2e/tests/landing/navigation.spec.ts`, within the `test("all anchor links on the page have valid hrefs", ...)`, update the conditional on line 105 to also check for `href` values starting with `"data:"` and `"vbscript:"`. To keep behavior consistent and simple, we can add them directly into the existing `if` condition using additional `||` clauses. No imports or helper methods are needed; we just extend the inline `startsWith` check.

The only change required is:

- In the loop that builds `invalidLinks`, change:

```ts
if (!href || href === "#" || href.startsWith("javascript:")) {
```

to:

```ts
if (
  !href ||
  href === "#" ||
  href.startsWith("javascript:") ||
  href.startsWith("data:") ||
  href.startsWith("vbscript:")
) {
```

This preserves the existing behavior and test expectations while closing the gap highlighted by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
