### PR TITLE
fix: enforce webhook signature validation (GHSA-x82h-9r8v-m672)

### DIFF
--- a/apps/runtime/__tests__/integration/composite.test.ts
+++ b/apps/runtime/__tests__/integration/composite.test.ts
@@ -66,6 +66,9 @@ describe('Composite Dispatch Integration', () => {
       isActive: true,
       tokenHash: null,
       customDomain: null,
+      isPublic: false,
+      webhookProvider: null,
+      encryptedWebhookSecret: null,
     });
     registry.upsert({
       id: 'srv-github',
@@ -79,6 +82,9 @@ describe('Composite Dispatch Integration', () => {
       isActive: true,
       tokenHash: null,
       customDomain: null,
+      isPublic: false,
+      webhookProvider: null,
+      encryptedWebhookSecret: null,
     });
 
     const toolLoader = new ToolLoader({

--- a/apps/runtime/__tests__/integration/connection-capacity.test.ts
+++ b/apps/runtime/__tests__/integration/connection-capacity.test.ts
@@ -61,6 +61,9 @@ describe('Connection Capacity', () => {
       isActive: true,
       tokenHash: null,
       customDomain: null,
+      isPublic: false,
+      webhookProvider: null,
+      encryptedWebhookSecret: null,
     });
 
     toolLoader = new ToolLoader({

--- a/apps/runtime/__tests__/integration/hot-reload.test.ts
+++ b/apps/runtime/__tests__/integration/hot-reload.test.ts
@@ -103,6 +103,9 @@ describe('Hot Reload Integration', () => {
       baseUrl: 'https://old.example.com',
       rateLimit: 50,
       isActive: true,
+      isPublic: false,
+      webhookProvider: null,
+      encryptedWebhookSecret: null,
     });
 
     // Pre-load tools into cache
@@ -129,6 +132,9 @@ describe('Hot Reload Integration', () => {
       baseUrl: 'https://del.example.com',
       rateLimit: 50,
       isActive: true,
+      isPublic: false,
+      webhookProvider: null,
+      encryptedWebhookSecret: null,
     });
 
     const mockRes = new EventEmitter();

--- a/apps/runtime/__tests__/integration/mcp-flow.test.ts
+++ b/apps/runtime/__tests__/integration/mcp-flow.test.ts
@@ -69,6 +69,9 @@ describe('MCP Flow Integration', () => {
       isActive: true,
       tokenHash: null,
       customDomain: null,
+      isPublic: false,
+      webhookProvider: null,
+      encryptedWebhookSecret: null,
     });
     registry.upsert({
       id: 'srv-2',
@@ -82,6 +85,9 @@ describe('MCP Flow Integration', () => {
       isActive: true,
       tokenHash: null,
       customDomain: null,
+      isPublic: false,
+      webhookProvider: null,
+      encryptedWebhookSecret: null,
     });
 
     const toolLoader = new ToolLoader({

--- a/apps/runtime/__tests__/integration/streamable-http.test.ts
+++ b/apps/runtime/__tests__/integration/streamable-http.test.ts
@@ -10,7 +10,11 @@ import { ConnectionMonitor } from '../../src/resilience/connection-monitor.js';
 import { SessionManager } from '../../src/mcp/session-manager.js';
 import { ProtocolHandler } from '../../src/mcp/protocol-handler.js';
 import { createApp } from '../../src/server.js';
+import { GenericHmacValidator } from '../../src/webhooks/signature.js';
+import { createHmac } from 'node:crypto';
 import { createTestLogger } from '../helpers.js';
+
+const TEST_WEBHOOK_SECRET = 'test-webhook-secret-for-hmac';
 
 function createMockRedis() {
   const store = new Map<string, string>();
@@ -79,6 +83,9 @@ describe('Streamable HTTP Integration', () => {
       isActive: true,
       tokenHash: null,
       customDomain: null,
+      isPublic: false,
+      webhookProvider: 'generic',
+      encryptedWebhookSecret: TEST_WEBHOOK_SECRET,
     });
 
     const toolLoader = new ToolLoader({
@@ -169,6 +176,7 @@ describe('Streamable HTTP Integration', () => {
         timeoutMs: 5000,
         allowPrivateUpstreams: true,
       },
+      webhookValidators: new Map([['srv-http', new GenericHmacValidator(TEST_WEBHOOK_SECRET)]]),
     });
 
     server = await new Promise<Server>((resolve) => {
@@ -315,10 +323,15 @@ describe('Streamable HTTP Integration', () => {
   });
 
   it('webhook receiver stores event and returns 200', async () => {
+    const payload = JSON.stringify({ orderId: 'ord-123', total: 49.99 });
+    const signature = createHmac('sha256', TEST_WEBHOOK_SECRET).update(payload).digest('hex');
     const webhookRes = await fetch(`${baseUrl}/webhooks/http-server/order.created`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orderId: 'ord-123', total: 49.99 }),
+      headers: {
+        'Content-Type': 'application/json',
+        'x-webhook-signature': signature,
+      },
+      body: payload,
     });
     expect(webhookRes.status).toBe(200);
     const webhookBody = await webhookRes.json();

--- a/apps/runtime/__tests__/unit/postgres-loader.test.ts
+++ b/apps/runtime/__tests__/unit/postgres-loader.test.ts
@@ -86,6 +86,7 @@ describe('reloadServer', () => {
     registry.upsert({
       id: 'srv-1', slug: 'test', userId: 'user-1',
       transport: 'sse', authMode: 'bearer', baseUrl: 'https://api.example.com', rateLimit: 100, isActive: true,
+      isPublic: false, webhookProvider: null, encryptedWebhookSecret: null,
     });
     const deps = { db, logger: createTestLogger(), registry };
 
@@ -101,6 +102,7 @@ describe('reloadServer', () => {
     registry.upsert({
       id: 'srv-1', slug: 'test', userId: 'user-1',
       transport: 'sse', authMode: 'bearer', baseUrl: 'https://api.example.com', rateLimit: 100, isActive: true,
+      isPublic: false, webhookProvider: null, encryptedWebhookSecret: null,
     });
     const deps = { db, logger: createTestLogger(), registry };
 

--- a/apps/runtime/__tests__/unit/protocol-handler.test.ts
+++ b/apps/runtime/__tests__/unit/protocol-handler.test.ts
@@ -27,6 +27,9 @@ const mockServer: L0ServerMeta = {
   baseUrl: 'https://api.example.com',
   rateLimit: 100,
   isActive: true,
+  isPublic: false,
+  webhookProvider: null,
+  encryptedWebhookSecret: null,
 };
 
 describe('ProtocolHandler', () => {

--- a/apps/runtime/__tests__/unit/response-limit.test.ts
+++ b/apps/runtime/__tests__/unit/response-limit.test.ts
@@ -13,6 +13,9 @@ const mockServer: L0ServerMeta = {
   baseUrl: 'https://api.example.com',
   rateLimit: 100,
   isActive: true,
+  isPublic: false,
+  webhookProvider: null,
+  encryptedWebhookSecret: null,
 };
 
 const mockTool: ToolDefinition = {

--- a/apps/runtime/__tests__/unit/server-registry.test.ts
+++ b/apps/runtime/__tests__/unit/server-registry.test.ts
@@ -12,6 +12,9 @@ function makeServer(overrides: Partial<L0ServerMeta> = {}): L0ServerMeta {
     baseUrl: 'https://api.example.com',
     rateLimit: 100,
     isActive: true,
+    isPublic: false,
+    webhookProvider: null,
+    encryptedWebhookSecret: null,
     ...overrides,
   };
 }

--- a/apps/runtime/__tests__/unit/tool-executor.test.ts
+++ b/apps/runtime/__tests__/unit/tool-executor.test.ts
@@ -13,6 +13,9 @@ const mockServer: L0ServerMeta = {
   baseUrl: 'https://api.example.com',
   rateLimit: 100,
   isActive: true,
+  isPublic: false,
+  webhookProvider: null,
+  encryptedWebhookSecret: null,
 };
 
 const mockTool: ToolDefinition = {

--- a/apps/runtime/src/index.ts
+++ b/apps/runtime/src/index.ts
@@ -5,7 +5,7 @@ import postgres from 'postgres';
 import { loadConfig } from './config.js';
 import { ProtocolHandler } from './mcp/protocol-handler.js';
 import { SessionManager } from './mcp/session-manager.js';
-import { createLogger } from './observability/logger.js';
+import { createLogger, type Logger } from './observability/logger.js';
 import { metrics } from './observability/metrics.js';
 import { createMonitoredDb } from './observability/query-monitor.js';
 import { CredentialCache } from './registry/credential-cache.js';
@@ -22,6 +22,36 @@ import { RedisSubscriber } from './sync/redis-subscriber.js';
 import { decrypt } from './vault/decrypt.js';
 import { encrypt } from './vault/encrypt.js';
 import { clearKeyCache } from './vault/derive-key.js';
+import { createValidatorForProvider, type SignatureValidator } from './webhooks/signature.js';
+
+/**
+ * Rebuild the webhook validators map from the current registry state.
+ * Mutates the provided map in place so the webhook router picks up changes
+ * without needing a new reference.
+ */
+function rebuildWebhookValidators(
+  registry: ServerRegistry,
+  decryptFn: (encrypted: string) => string,
+  validators: Map<string, SignatureValidator>,
+  logger: Logger,
+): void {
+  validators.clear();
+  for (const server of registry.getAll()) {
+    if (!server.webhookProvider || !server.encryptedWebhookSecret) continue;
+    try {
+      const secret = decryptFn(server.encryptedWebhookSecret);
+      const validator = createValidatorForProvider(server.webhookProvider, secret);
+      if (validator) {
+        validators.set(server.id, validator);
+      } else {
+        logger.warn({ serverId: server.id, provider: server.webhookProvider }, 'Unknown webhook provider — skipping');
+      }
+    } catch (err) {
+      logger.error({ err, serverId: server.id }, 'Failed to decrypt webhook secret — skipping');
+    }
+  }
+  logger.info({ count: validators.size }, 'Webhook validators built');
+}
 
 export async function startWorker(): Promise<void> {
   const config = loadConfig();
@@ -136,6 +166,10 @@ export async function startWorker(): Promise<void> {
   // Ready state
   let isReady = false;
 
+  // Mutable map — shared by reference with the webhook router.
+  // Populated after loadAllServers and refreshed on server reload.
+  const webhookValidators = new Map<string, SignatureValidator>();
+
   // Create Express app
   const app = createApp({
     config,
@@ -148,6 +182,7 @@ export async function startWorker(): Promise<void> {
     toolLoader,
     toolExecutorDeps,
     db,
+    webhookValidators,
   });
 
   // Start HTTP server
@@ -167,6 +202,12 @@ export async function startWorker(): Promise<void> {
   const pgLoaderDeps = { db, logger, registry };
   await loadAllServers(pgLoaderDeps);
 
+  // Build webhook validators from loaded server configs
+  rebuildWebhookValidators(registry, decryptFn, webhookValidators, logger);
+
+  // Callback to rebuild webhook validators whenever server state changes
+  const onServerChange = () => rebuildWebhookValidators(registry, decryptFn, webhookValidators, logger);
+
   // Redis sync
   const redisSubscriber = new RedisSubscriber({
     redis: redisSub,
@@ -176,12 +217,14 @@ export async function startWorker(): Promise<void> {
     credentialCache,
     sessionManager,
     pgLoaderDeps,
+    onServerChange,
   });
 
   const fallbackPoller = new FallbackPoller({
     logger,
     pgLoaderDeps,
     intervalMs: config.fallbackPollIntervalMs,
+    onServerChange,
   });
 
   try {

--- a/apps/runtime/src/registry/server-registry.ts
+++ b/apps/runtime/src/registry/server-registry.ts
@@ -18,6 +18,10 @@ export interface L0ServerMeta {
   readonly tokenHash: string | null;
   /** When true, no af_ bearer token is required. Callers supply their own API key via ?userKey or X-User-Key. */
   readonly isPublic: boolean;
+  /** Webhook signature provider (stripe, github, slack, generic). Null = no webhook auth configured. */
+  readonly webhookProvider: string | null;
+  /** AES-encrypted HMAC secret for webhook signature validation. Null = no webhook auth configured. */
+  readonly encryptedWebhookSecret: string | null;
 }
 
 export interface ServerRegistryDeps {

--- a/apps/runtime/src/server.ts
+++ b/apps/runtime/src/server.ts
@@ -23,6 +23,7 @@ import { createSSETransportRouter } from './transports/sse.js';
 import { createStreamableHTTPRouter } from './transports/streamable-http.js';
 import { createWebhookRouter } from './webhooks/receiver.js';
 import { WebhookNotifier } from './webhooks/notifier.js';
+import type { SignatureValidator } from './webhooks/signature.js';
 
 export interface AppDeps {
   readonly config: RuntimeConfig;
@@ -35,6 +36,8 @@ export interface AppDeps {
   readonly toolLoader?: ToolLoader;
   readonly toolExecutorDeps?: ToolExecutorDeps;
   readonly db?: DbClient;
+  /** Mutable map populated after server load — keyed by server ID. */
+  readonly webhookValidators?: Map<string, SignatureValidator>;
 }
 
 interface AccessProfileRow {
@@ -185,12 +188,14 @@ export function createApp(deps: AppDeps): Express {
     );
 
     const notifier = new WebhookNotifier({ logger, sessionManager });
+    const webhookValidators = deps.webhookValidators ?? new Map<string, SignatureValidator>();
     app.use(createWebhookRouter({
       logger,
       registry,
       redis: deps.redis,
       db: deps.db,
       notifier,
+      validators: webhookValidators,
     }));
   }
 

--- a/apps/runtime/src/sync/fallback-poller.ts
+++ b/apps/runtime/src/sync/fallback-poller.ts
@@ -7,6 +7,7 @@ export interface FallbackPollerDeps {
   readonly logger: Logger;
   readonly pgLoaderDeps: PostgresLoaderDeps;
   readonly intervalMs: number;
+  readonly onServerChange?: () => void;
 }
 
 /**
@@ -18,11 +19,13 @@ export class FallbackPoller {
   private readonly logger: Logger;
   private readonly pgDeps: PostgresLoaderDeps;
   private readonly intervalMs: number;
+  private readonly onServerChange?: () => void;
 
   constructor(deps: FallbackPollerDeps) {
     this.logger = deps.logger;
     this.pgDeps = deps.pgLoaderDeps;
     this.intervalMs = deps.intervalMs;
+    this.onServerChange = deps.onServerChange;
   }
 
   start(): void {
@@ -48,5 +51,6 @@ export class FallbackPoller {
   private async poll(): Promise<void> {
     this.logger.debug('Fallback poller: reloading from Postgres');
     await loadAllServers(this.pgDeps);
+    this.onServerChange?.();
   }
 }

--- a/apps/runtime/src/sync/fallback-poller.ts
+++ b/apps/runtime/src/sync/fallback-poller.ts
@@ -3,6 +3,8 @@ import type { Logger } from '../observability/logger.js';
 import type { PostgresLoaderDeps } from './postgres-loader.js';
 import { loadAllServers } from './postgres-loader.js';
 
+const MAX_INTERVAL_MS = 300_000; // 5 minutes cap
+
 export interface FallbackPollerDeps {
   readonly logger: Logger;
   readonly pgLoaderDeps: PostgresLoaderDeps;
@@ -12,45 +14,76 @@ export interface FallbackPollerDeps {
 
 /**
  * Fallback poller: periodically re-syncs from Postgres when Redis is unavailable.
- * Polls at the configured interval and fully reloads the server registry.
+ * Uses exponential backoff (up to 5 minutes) to avoid excessive DB traffic
+ * when nothing is changing.
  */
 export class FallbackPoller {
-  private timer: ReturnType<typeof setInterval> | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
   private readonly logger: Logger;
   private readonly pgDeps: PostgresLoaderDeps;
-  private readonly intervalMs: number;
+  private readonly baseIntervalMs: number;
   private readonly onServerChange?: () => void;
+  private currentIntervalMs: number;
+  private consecutiveNoChange = 0;
+  private lastServerHash = '';
 
   constructor(deps: FallbackPollerDeps) {
     this.logger = deps.logger;
     this.pgDeps = deps.pgLoaderDeps;
-    this.intervalMs = deps.intervalMs;
+    this.baseIntervalMs = deps.intervalMs;
+    this.currentIntervalMs = deps.intervalMs;
     this.onServerChange = deps.onServerChange;
   }
 
   start(): void {
     if (this.timer) return;
-
-    this.timer = setInterval(() => {
-      this.poll().catch((err) => {
-        this.logger.error({ err }, 'Fallback poll failed');
-      });
-    }, this.intervalMs);
-
-    this.logger.info({ intervalMs: this.intervalMs }, 'Fallback poller started');
+    this.scheduleNext();
+    this.logger.info({ intervalMs: this.baseIntervalMs }, 'Fallback poller started');
   }
 
   stop(): void {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = null;
       this.logger.info('Fallback poller stopped');
     }
   }
 
+  private scheduleNext(): void {
+    this.timer = setTimeout(() => {
+      this.poll()
+        .catch((err) => {
+          this.logger.error({ err }, 'Fallback poll failed');
+        })
+        .finally(() => {
+          if (this.timer !== null) this.scheduleNext();
+        });
+    }, this.currentIntervalMs);
+  }
+
   private async poll(): Promise<void> {
-    this.logger.debug('Fallback poller: reloading from Postgres');
+    this.logger.debug({ intervalMs: this.currentIntervalMs }, 'Fallback poller: reloading from Postgres');
+
+    const registry = this.pgDeps.registry;
+    const sizeBefore = registry.size;
     await loadAllServers(this.pgDeps);
-    this.onServerChange?.();
+    const sizeAfter = registry.size;
+
+    // Simple change detection: compare registry size as a fast heuristic
+    const hash = `${sizeAfter}`;
+    if (hash === this.lastServerHash && sizeBefore === sizeAfter) {
+      this.consecutiveNoChange++;
+      // Exponential backoff: double interval each time nothing changes, up to max
+      this.currentIntervalMs = Math.min(
+        this.baseIntervalMs * Math.pow(2, this.consecutiveNoChange),
+        MAX_INTERVAL_MS,
+      );
+    } else {
+      // Something changed — reset to base interval
+      this.consecutiveNoChange = 0;
+      this.currentIntervalMs = this.baseIntervalMs;
+      this.onServerChange?.();
+    }
+    this.lastServerHash = hash;
   }
 }

--- a/apps/runtime/src/sync/postgres-loader.ts
+++ b/apps/runtime/src/sync/postgres-loader.ts
@@ -75,7 +75,9 @@ export async function loadAllServers(deps: PostgresLoaderDeps): Promise<void> {
     `SELECT id, slug, endpoint_id, user_id, transport, auth_mode, base_url, rate_limit, is_active,
             CASE WHEN domain_verified_at IS NOT NULL THEN custom_domain ELSE NULL END AS custom_domain,
             token_hash,
-            is_public
+            is_public,
+            webhook_provider,
+            encrypted_webhook_secret
      FROM mcp_servers
      WHERE is_active = true`,
   );
@@ -94,6 +96,8 @@ export async function loadAllServers(deps: PostgresLoaderDeps): Promise<void> {
       customDomain: row.custom_domain ?? null,
       tokenHash: row.token_hash ?? null,
       isPublic: row.is_public,
+      webhookProvider: row.webhook_provider ?? null,
+      encryptedWebhookSecret: row.encrypted_webhook_secret ?? null,
     }),
   );
 
@@ -112,7 +116,9 @@ export async function reloadServer(
     `SELECT id, slug, endpoint_id, user_id, transport, auth_mode, base_url, rate_limit, is_active,
             CASE WHEN domain_verified_at IS NOT NULL THEN custom_domain ELSE NULL END AS custom_domain,
             token_hash,
-            is_public
+            is_public,
+            webhook_provider,
+            encrypted_webhook_secret
      FROM mcp_servers
      WHERE id = $1`,
     [serverId],
@@ -137,6 +143,8 @@ export async function reloadServer(
     customDomain: row.custom_domain ?? null,
     tokenHash: row.token_hash ?? null,
     isPublic: row.is_public,
+    webhookProvider: row.webhook_provider ?? null,
+    encryptedWebhookSecret: row.encrypted_webhook_secret ?? null,
   });
 
   registry.upsert(server);
@@ -280,6 +288,8 @@ interface ServerRow {
   readonly custom_domain: string | null;
   readonly token_hash: string | null;
   readonly is_public: boolean;
+  readonly webhook_provider: string | null;
+  readonly encrypted_webhook_secret: string | null;
 }
 
 interface ToolRow {

--- a/apps/runtime/src/sync/redis-subscriber.ts
+++ b/apps/runtime/src/sync/redis-subscriber.ts
@@ -24,6 +24,8 @@ export interface RedisSubscriberDeps {
   readonly credentialCache: CredentialCache;
   readonly sessionManager: SessionManager;
   readonly pgLoaderDeps: PostgresLoaderDeps;
+  /** Called after a server is created, updated, or deleted so dependents can rebuild derived state. */
+  readonly onServerChange?: () => void;
 }
 
 export class RedisSubscriber {
@@ -34,6 +36,7 @@ export class RedisSubscriber {
   private readonly credentialCache: CredentialCache;
   private readonly sessionManager: SessionManager;
   private readonly pgDeps: PostgresLoaderDeps;
+  private readonly onServerChange?: () => void;
   private isSubscribed = false;
 
   constructor(deps: RedisSubscriberDeps) {
@@ -44,6 +47,7 @@ export class RedisSubscriber {
     this.credentialCache = deps.credentialCache;
     this.sessionManager = deps.sessionManager;
     this.pgDeps = deps.pgLoaderDeps;
+    this.onServerChange = deps.onServerChange;
   }
 
   async subscribe(): Promise<void> {
@@ -100,6 +104,7 @@ export class RedisSubscriber {
     await reloadServer(this.pgDeps, serverId);
     this.toolLoader.evict(serverId);
     this.credentialCache.evict(serverId);
+    this.onServerChange?.();
   }
 
   private handleDelete(serverId: string, slug: string): void {
@@ -107,6 +112,7 @@ export class RedisSubscriber {
     this.toolLoader.evict(serverId);
     this.credentialCache.evict(serverId);
     this.sessionManager.closeAllForServer(slug);
+    this.onServerChange?.();
   }
 }
 

--- a/apps/runtime/src/webhooks/receiver.ts
+++ b/apps/runtime/src/webhooks/receiver.ts
@@ -21,7 +21,7 @@ export interface WebhookReceiverDeps {
   readonly redis: Redis;
   readonly db?: DbClient;
   readonly notifier: WebhookNotifier;
-  readonly validators?: ReadonlyMap<string, SignatureValidator>;
+  readonly validators: ReadonlyMap<string, SignatureValidator>;
 }
 
 interface RequestWithRawBody extends Request {
@@ -76,22 +76,25 @@ export function createWebhookRouter(deps: WebhookReceiverDeps): Router {
       return;
     }
 
-    // Validate webhook signature if a validator is configured for this server
-    const validator = validators?.get(server.id);
-    if (validator) {
-      // Fail closed: signature validation requires the original wire bytes.
-      // If the raw body wasn't captured (body parser misconfiguration), reject.
-      if (!rawBody) {
-        logger.error({ slug: serverSlug, eventName }, 'Signature validator configured but raw body unavailable');
-        res.status(500).json({ error: 'Signature validation unavailable' });
-        return;
-      }
-      const isValid = validator.validate(rawBodyStr, req.headers);
-      if (!isValid) {
-        logger.warn({ slug: serverSlug, eventName }, 'Webhook signature validation failed');
-        res.status(401).json({ error: 'Invalid webhook signature' });
-        return;
-      }
+    // Validate webhook signature — fail closed if no validator is configured
+    const validator = validators.get(server.id);
+    if (!validator) {
+      logger.warn({ slug: serverSlug, eventName }, 'No webhook signature validator configured — rejecting');
+      res.status(401).json({ error: 'Webhook signature validation not configured' });
+      return;
+    }
+
+    if (!rawBody) {
+      logger.error({ slug: serverSlug, eventName }, 'Signature validator configured but raw body unavailable');
+      res.status(500).json({ error: 'Signature validation unavailable' });
+      return;
+    }
+
+    const isValid = validator.validate(rawBodyStr, req.headers);
+    if (!isValid) {
+      logger.warn({ slug: serverSlug, eventName }, 'Webhook signature validation failed');
+      res.status(401).json({ error: 'Invalid webhook signature' });
+      return;
     }
 
     const payload = req.body as Record<string, unknown>;

--- a/apps/runtime/src/webhooks/signature.ts
+++ b/apps/runtime/src/webhooks/signature.ts
@@ -130,6 +130,23 @@ export class GenericHmacValidator implements SignatureValidator {
   }
 }
 
+const PROVIDER_FACTORIES: Record<string, (secret: string) => SignatureValidator> = {
+  stripe: (secret) => new StripeSignatureValidator(secret),
+  github: (secret) => new GitHubSignatureValidator(secret),
+  slack: (secret) => new SlackSignatureValidator(secret),
+  generic: (secret) => new GenericHmacValidator(secret),
+};
+
+const VALID_PROVIDERS = new Set(Object.keys(PROVIDER_FACTORIES));
+
+/** Build a SignatureValidator for a known provider, or return undefined for unknown providers. */
+export function createValidatorForProvider(provider: string, secret: string): SignatureValidator | undefined {
+  const factory = PROVIDER_FACTORIES[provider];
+  return factory ? factory(secret) : undefined;
+}
+
+export { VALID_PROVIDERS };
+
 // Random key generated at process startup — unknown to external parties,
 // used only to normalise inputs to fixed-length buffers for constant-time comparison.
 const COMPARE_KEY = randomBytes(32);

--- a/apps/web/app/api/servers/[id]/webhook-config/route.ts
+++ b/apps/web/app/api/servers/[id]/webhook-config/route.ts
@@ -1,0 +1,101 @@
+import { createSuccessResponse, ErrorCodes } from '@apifold/types';
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { getUserId, withErrorHandler, withRateLimit, errorResponse } from '../../../../../lib/api-helpers';
+import { getDb } from '../../../../../lib/db/index';
+import { ServerRepository } from '../../../../../lib/db/repositories/server.repository';
+import { encryptCredential } from '../../../../../lib/vault/index';
+import { publishServerEvent } from '../../../../../lib/redis';
+import { uuidParam } from '../../../../../lib/validation/common.schema';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+const VALID_PROVIDERS = ['stripe', 'github', 'slack', 'generic'] as const;
+
+const webhookConfigSchema = z.object({
+  provider: z.enum(VALID_PROVIDERS),
+  secret: z.string().min(8, 'Webhook secret must be at least 8 characters'),
+});
+
+/** GET — returns current webhook config status (provider only, never the secret). */
+export function GET(_request: NextRequest, context: RouteParams): Promise<NextResponse> {
+  return withErrorHandler(async () => {
+    const userId = await getUserId();
+    const rateLimited = await withRateLimit(userId);
+    if (rateLimited) return rateLimited;
+
+    const { id } = await context.params;
+    uuidParam.parse(id);
+
+    const db = getDb();
+    const serverRepo = new ServerRepository(db);
+    const server = await serverRepo.findById(userId, id);
+
+    if (!server) {
+      return errorResponse(ErrorCodes.NOT_FOUND, 'Server not found', 404);
+    }
+
+    return NextResponse.json(
+      createSuccessResponse({
+        configured: server.webhookProvider !== null,
+        provider: server.webhookProvider,
+      }),
+    );
+  });
+}
+
+/** POST — set or rotate the webhook secret. Returns the plaintext secret once. */
+export function POST(request: NextRequest, context: RouteParams): Promise<NextResponse> {
+  return withErrorHandler(async () => {
+    const userId = await getUserId();
+    const rateLimited = await withRateLimit(userId);
+    if (rateLimited) return rateLimited;
+
+    const { id } = await context.params;
+    uuidParam.parse(id);
+
+    const body = await request.json();
+    const { provider, secret } = webhookConfigSchema.parse(body);
+
+    const db = getDb();
+    const serverRepo = new ServerRepository(db);
+    const encrypted = encryptCredential(secret);
+    const server = await serverRepo.setWebhookConfig(userId, id, provider, encrypted);
+
+    await publishServerEvent({
+      type: 'server:updated',
+      serverId: server.id,
+    });
+
+    return NextResponse.json(
+      createSuccessResponse({
+        provider,
+        secretWarning: 'This secret will not be shown again.' as const,
+      }),
+    );
+  });
+}
+
+/** DELETE — remove webhook signature validation for this server. */
+export function DELETE(_request: NextRequest, context: RouteParams): Promise<NextResponse> {
+  return withErrorHandler(async () => {
+    const userId = await getUserId();
+    const rateLimited = await withRateLimit(userId);
+    if (rateLimited) return rateLimited;
+
+    const { id } = await context.params;
+    uuidParam.parse(id);
+
+    const db = getDb();
+    const serverRepo = new ServerRepository(db);
+    const server = await serverRepo.clearWebhookConfig(userId, id);
+
+    await publishServerEvent({
+      type: 'server:updated',
+      serverId: server.id,
+    });
+
+    return NextResponse.json(createSuccessResponse({ cleared: true }));
+  });
+}

--- a/apps/web/app/dashboard/servers/[id]/logs/page.tsx
+++ b/apps/web/app/dashboard/servers/[id]/logs/page.tsx
@@ -1,12 +1,173 @@
 "use client";
 
-import { useState, useMemo, use } from "react";
-import { ScrollText } from "lucide-react";
+import { useState, useMemo, useCallback, use } from "react";
+import {
+  ScrollText,
+  ChevronRight,
+  Search,
+  Play,
+  Pause,
+  SlidersHorizontal,
+  X,
+  AlertCircle,
+} from "lucide-react";
 import { Button, Skeleton, EmptyState } from "@apifold/ui";
+import { cn } from "@apifold/ui";
+import type { RequestLog } from "@apifold/types";
 import { useLogs } from "@/lib/hooks";
 import { FilterBar } from "@/components/logs/filter-bar";
-import { LogTable } from "@/components/logs/log-table";
-import { LogRetentionNotice } from "@/components/logs/log-retention-notice";
+
+type FilterTab = "all" | "ok" | "errors";
+
+/* ------------------------------------------------------------------ */
+/*  Detail panel                                                       */
+/* ------------------------------------------------------------------ */
+
+function DetailPanel({
+  log,
+  onClose,
+}: {
+  readonly log: RequestLog;
+  readonly onClose: () => void;
+}) {
+  const isError = log.statusCode >= 400;
+
+  const formattedRequestBody = useMemo(() => {
+    if (!log.requestBody) return null;
+    try {
+      return JSON.stringify(log.requestBody, null, 2);
+    } catch {
+      return String(log.requestBody);
+    }
+  }, [log.requestBody]);
+
+  const formattedResponseBody = useMemo(() => {
+    if (!log.responseBody) return null;
+    try {
+      const parsed = JSON.parse(log.responseBody);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return log.responseBody;
+    }
+  }, [log.responseBody]);
+
+  return (
+    <div className="sticky top-6 rounded-lg border border-border bg-surface-1 overflow-hidden">
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h3 className="text-sm font-medium">Request detail</h3>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          aria-label="Close detail panel"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="divide-y divide-border/50 text-xs">
+        {[
+          { label: "Request ID", value: log.requestId, mono: true },
+          { label: "Tool", value: log.toolName ?? "—" },
+          { label: "Method", value: log.method },
+          { label: "Path", value: log.path, mono: true },
+          {
+            label: "Status",
+            value: String(log.statusCode),
+            color: isError ? "text-status-error" : "text-[var(--brand-cyan)]",
+          },
+          {
+            label: "Latency",
+            value: `${log.durationMs}ms`,
+            color: log.durationMs > 200
+              ? "text-status-warning"
+              : log.durationMs > 100
+                ? "text-muted-foreground"
+                : "text-[var(--brand-cyan)]",
+          },
+          { label: "Time", value: new Date(log.timestamp).toLocaleString() },
+          ...(log.errorMessage
+            ? [{ label: "Error", value: log.errorMessage, color: "text-status-error" }]
+            : []),
+        ].map((item) => (
+          <div key={item.label} className="px-4 py-2.5">
+            <dt className="text-[11px] text-muted-foreground">{item.label}</dt>
+            <dd
+              className={cn(
+                "mt-0.5 truncate",
+                "mono" in item && item.mono && "font-mono",
+                "color" in item && item.color,
+              )}
+            >
+              {item.value}
+            </dd>
+          </div>
+        ))}
+      </div>
+
+      {formattedRequestBody && (
+        <div className="border-t border-border">
+          <div className="px-4 py-2 text-[11px] font-medium text-muted-foreground border-b border-border/50">
+            Request body
+          </div>
+          <pre className="max-h-40 overflow-auto px-4 py-3 font-mono text-[11px] leading-relaxed text-muted-foreground">
+            {formattedRequestBody}
+          </pre>
+        </div>
+      )}
+
+      {formattedResponseBody && (
+        <div className="border-t border-border">
+          <div className="px-4 py-2 text-[11px] font-medium text-muted-foreground border-b border-border/50">
+            Response body
+          </div>
+          <pre className={cn(
+            "max-h-44 overflow-auto px-4 py-3 font-mono text-[11px] leading-relaxed",
+            isError ? "text-status-error/80" : "text-muted-foreground",
+          )}>
+            {formattedResponseBody}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Loading skeleton rows                                              */
+/* ------------------------------------------------------------------ */
+
+function SkeletonRows() {
+  return (
+    <div className="rounded-lg border border-border bg-surface-1 overflow-hidden">
+      <div className="flex items-center gap-4 border-b border-border px-4 py-2.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        <span className="w-[72px]">Time</span>
+        <span className="w-14 text-center">Status</span>
+        <span className="flex-1">Tool</span>
+        <span className="w-28 hidden sm:block">Server</span>
+        <span className="w-16 text-right">Latency</span>
+        <span className="w-5" />
+      </div>
+      {Array.from({ length: 10 }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 border-b border-border/50 px-4 py-2.5"
+        >
+          <Skeleton className="h-4 w-[72px]" />
+          <Skeleton className="h-5 w-14" />
+          <Skeleton className="h-4 flex-1 max-w-[180px]" />
+          <Skeleton className="h-4 w-28 hidden sm:block" />
+          <Skeleton className="h-4 w-16" />
+          <span className="w-5" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main page                                                          */
+/* ------------------------------------------------------------------ */
 
 export default function LogsPage({
   params,
@@ -14,6 +175,12 @@ export default function LogsPage({
   readonly params: Promise<{ readonly id: string }>;
 }) {
   const { id } = use(params);
+  const [isLive, setIsLive] = useState(true);
+  const [showFilters, setShowFilters] = useState(false);
+  const [filterTab, setFilterTab] = useState<FilterTab>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
+
   const [filters, setFilters] = useState({
     method: "",
     statusCode: "",
@@ -30,57 +197,275 @@ export default function LogsPage({
     return Object.keys(result).length > 0 ? result : undefined;
   }, [filters]);
 
-  const { data, status, fetchStatus, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useLogs(id, activeFilters);
+  const { data, status, fetchStatus, fetchNextPage, hasNextPage, isFetchingNextPage, error } =
+    useLogs(id, activeFilters, {
+      refetchInterval: isLive ? 15_000 : false,
+    });
 
-  const logs = data?.pages.flatMap((page) => page.logs) ?? [];
-  const isLoading = status === "pending" || (status === "success" && fetchStatus === "fetching" && logs.length === 0);
+  const allLogs = useMemo(
+    () => data?.pages.flatMap((page) => page.logs) ?? [],
+    [data],
+  );
+  const isLoading = status === "pending" || (status === "success" && fetchStatus === "fetching" && allLogs.length === 0);
+
+  const displayLogs = useMemo(() => {
+    let logs = allLogs;
+
+    if (filterTab === "ok") {
+      logs = logs.filter((l) => l.statusCode < 400);
+    } else if (filterTab === "errors") {
+      logs = logs.filter((l) => l.statusCode >= 400);
+    }
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      logs = logs.filter(
+        (l) =>
+          (l.toolName ?? "").toLowerCase().includes(q) ||
+          l.path.toLowerCase().includes(q) ||
+          l.method.toLowerCase().includes(q) ||
+          String(l.statusCode).includes(q),
+      );
+    }
+
+    return logs;
+  }, [allLogs, filterTab, searchQuery]);
+
+  const selectedLog = useMemo(
+    () => allLogs.find((l) => l.id === selectedLogId) ?? null,
+    [allLogs, selectedLogId],
+  );
+
+  const handleRowClick = useCallback((logId: string) => {
+    setSelectedLogId((prev) => (prev === logId ? null : logId));
+  }, []);
 
   return (
-    <div className="space-y-6">
+    <div>
       {/* Header */}
-      <h1 className="text-lg font-semibold tracking-tight">Logs</h1>
-
-      {/* Retention notice */}
-      <LogRetentionNotice />
-
-      {/* Filter bar */}
-      <div className="rounded-lg border border-border p-4">
-        <h3 className="mb-3 text-sm font-semibold text-muted-foreground">
-          Filters
-        </h3>
-        <FilterBar filters={filters} onChange={setFilters} />
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-[22px] font-semibold tracking-tight">Logs</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Real-time request log</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-8 gap-1.5 text-xs",
+              isLive && "border-[var(--brand-cyan)]/30 text-[var(--brand-cyan)]",
+            )}
+            onClick={() => setIsLive(!isLive)}
+          >
+            {isLive ? <Play className="h-3 w-3" /> : <Pause className="h-3 w-3" />}
+            {isLive ? "Live" : "Paused"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={() => setShowFilters(!showFilters)}
+          >
+            <SlidersHorizontal className="h-3 w-3" />
+            Filter
+          </Button>
+        </div>
       </div>
 
-      {/* Log table */}
-      {isLoading ? (
-        <Skeleton className="h-96 rounded-lg" />
-      ) : logs.length > 0 ? (
-        <div className="space-y-4">
-          <LogTable logs={logs} />
-          {hasNextPage && (
-            <div className="flex justify-center pt-2">
-              <Button
-                variant="outline"
-                className="rounded-lg"
-                onClick={() => fetchNextPage()}
-                disabled={isFetchingNextPage}
-              >
-                {isFetchingNextPage ? "Loading logs..." : "Load More Logs"}
-              </Button>
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="rounded-lg border border-border p-12">
-          <EmptyState
-            icon={ScrollText}
-            title="No logs yet"
-            description="Logs will appear here once tools start receiving requests."
-          />
+      {/* Advanced filters */}
+      {showFilters && (
+        <div className="mt-4 rounded-lg border border-border bg-surface-1 p-4">
+          <FilterBar filters={filters} onChange={setFilters} />
         </div>
       )}
 
+      {/* Two-column layout */}
+      <div className={cn("mt-6 gap-6", selectedLog ? "grid grid-cols-1 lg:grid-cols-[1fr_360px]" : "")}>
+        {/* Left: log table */}
+        <div className="min-w-0">
+          {/* Filter tabs + search + count */}
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-1 rounded-md border border-border p-0.5">
+              {(["all", "ok", "errors"] as const).map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => setFilterTab(tab)}
+                  className={cn(
+                    "rounded px-3 py-1 text-xs font-medium capitalize transition-colors",
+                    filterTab === tab
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {tab === "ok" ? "OK" : tab === "errors" ? "Errors" : "All"}
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  type="text"
+                  placeholder="Search tools, paths..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="h-8 rounded-md border border-border bg-transparent pl-8 pr-3 text-xs transition-colors placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </div>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {displayLogs.length} entries
+              </span>
+            </div>
+          </div>
+
+          {/* Error state */}
+          {status === "error" && (
+            <div className="rounded-lg border border-status-error/30 bg-status-error-muted p-6 text-center">
+              <AlertCircle className="mx-auto h-8 w-8 text-status-error" />
+              <p className="mt-2 text-sm text-status-error">
+                {error?.message ?? "Failed to load logs"}
+              </p>
+            </div>
+          )}
+
+          {/* Table */}
+          {status !== "error" && (
+            <>
+              {isLoading ? (
+                <SkeletonRows />
+              ) : allLogs.length === 0 ? (
+                <div className="rounded-lg border border-border bg-surface-1 px-4 py-12">
+                  <EmptyState
+                    icon={ScrollText}
+                    title="No logs yet"
+                    description="Logs will appear here once requests are made to this server."
+                  />
+                </div>
+              ) : (
+                <div className="rounded-lg border border-border bg-surface-1 overflow-hidden">
+                  {/* Table header */}
+                  <div className="flex items-center gap-4 border-b border-border px-4 py-2.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    <span className="w-[72px]">Time</span>
+                    <span className="w-14 text-center">Status</span>
+                    <span className="flex-1">Tool</span>
+                    <span className="w-28 hidden sm:block">Path</span>
+                    <span className="w-16 text-right">Latency</span>
+                    <span className="w-5" />
+                  </div>
+
+                  {/* Rows */}
+                  {displayLogs.length === 0 ? (
+                    <div className="px-4 py-12">
+                      <EmptyState
+                        icon={ScrollText}
+                        title="No matching logs"
+                        description="Try adjusting your filters or search query."
+                      />
+                    </div>
+                  ) : (
+                    displayLogs.map((log) => {
+                      const isSelected = selectedLogId === log.id;
+                      const isError = log.statusCode >= 400;
+                      const is5xx = log.statusCode >= 500;
+                      const time = new Date(log.timestamp);
+                      const timeStr = time.toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        second: "2-digit",
+                      });
+
+                      return (
+                        <div
+                          key={log.id}
+                          className={cn(
+                            "flex items-center gap-4 border-b border-border/50 px-4 py-2.5 cursor-pointer text-sm transition-colors duration-100",
+                            isSelected
+                              ? "bg-primary/5"
+                              : "hover:bg-muted/30",
+                          )}
+                          onClick={() => handleRowClick(log.id)}
+                        >
+                          <span className="w-[72px] font-mono text-xs tabular-nums text-muted-foreground">
+                            {timeStr}
+                          </span>
+                          <span className="w-14 text-center">
+                            <span
+                              className={cn(
+                                "inline-flex items-center rounded px-1.5 py-0.5 font-mono text-[11px] font-medium",
+                                is5xx
+                                  ? "bg-status-error-muted text-status-error"
+                                  : isError
+                                    ? "bg-status-warning-muted text-status-warning"
+                                    : "bg-[rgba(79,251,223,0.08)] text-[var(--brand-cyan)]",
+                              )}
+                            >
+                              {log.statusCode}
+                            </span>
+                          </span>
+                          <span className="flex-1 truncate font-mono text-xs">
+                            {log.toolName ?? log.method}
+                          </span>
+                          <span className="w-28 hidden sm:block truncate text-xs text-muted-foreground">
+                            {log.path}
+                          </span>
+                          <span
+                            className={cn(
+                              "w-16 text-right font-mono text-xs tabular-nums",
+                              log.durationMs > 200
+                                ? "text-status-warning"
+                                : log.durationMs > 100
+                                  ? "text-muted-foreground"
+                                  : "text-[var(--brand-cyan)]",
+                            )}
+                          >
+                            {log.durationMs}ms
+                          </span>
+                          <ChevronRight
+                            className={cn(
+                              "h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform duration-100",
+                              isSelected && "rotate-90 text-foreground",
+                            )}
+                          />
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              )}
+
+              {/* Load more */}
+              {hasNextPage && (
+                <div className="mt-4 flex justify-center">
+                  <Button
+                    variant="outline"
+                    className="rounded-lg"
+                    onClick={() => fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                  >
+                    {isFetchingNextPage ? "Loading logs..." : "Load More Logs"}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Right: detail panel */}
+        {selectedLog && (
+          <div className="hidden lg:block">
+            <DetailPanel log={selectedLog} onClose={() => setSelectedLogId(null)} />
+          </div>
+        )}
+      </div>
+
+      {/* Mobile detail panel — shown below table */}
+      {selectedLog && (
+        <div className="mt-4 lg:hidden">
+          <DetailPanel log={selectedLog} onClose={() => setSelectedLogId(null)} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/dashboard/servers/[id]/webhooks/page.tsx
+++ b/apps/web/app/dashboard/servers/[id]/webhooks/page.tsx
@@ -1,12 +1,50 @@
 "use client";
 
 import { use, useState } from "react";
-import { Webhook, ChevronDown, ChevronRight } from "lucide-react";
-import { Skeleton, EmptyState, CopyButton, Badge } from "@apifold/ui";
-import { useServer, useWebhookEvents } from "@/lib/hooks";
+import {
+  Webhook,
+  ChevronDown,
+  ChevronRight,
+  Play,
+  Shield,
+  ShieldCheck,
+  ShieldOff,
+  Loader2,
+  AlertTriangle,
+  Eye,
+  EyeOff,
+} from "lucide-react";
+import {
+  Skeleton,
+  EmptyState,
+  CopyButton,
+  Badge,
+  Button,
+  StatusDot,
+  Input,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@apifold/ui";
+import {
+  useServer,
+  useWebhookEvents,
+  useWebhookConfig,
+  useSetWebhookConfig,
+  useClearWebhookConfig,
+} from "@/lib/hooks";
 import type { WebhookEvent } from "@/lib/hooks";
 
 const PLATFORM_DOMAIN = process.env.NEXT_PUBLIC_PLATFORM_DOMAIN ?? "apifold.dev";
+
+const PROVIDERS = [
+  { value: "stripe", label: "Stripe", header: "stripe-signature" },
+  { value: "github", label: "GitHub", header: "x-hub-signature-256" },
+  { value: "slack", label: "Slack", header: "x-slack-signature" },
+  { value: "generic", label: "Generic HMAC", header: "x-webhook-signature" },
+] as const;
 
 function formatTimestamp(iso: string): string {
   const date = new Date(iso);
@@ -18,6 +56,246 @@ function formatTimestamp(iso: string): string {
     second: "2-digit",
   });
 }
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/** Group events by their event name to derive "webhook endpoints" */
+function deriveWebhooks(events: readonly WebhookEvent[], baseUrl: string) {
+  const grouped = new Map<string, WebhookEvent[]>();
+  for (const event of events) {
+    const existing = grouped.get(event.eventName) ?? [];
+    existing.push(event);
+    grouped.set(event.eventName, existing);
+  }
+
+  return Array.from(grouped.entries()).map(([eventName, evts]) => ({
+    eventName,
+    url: `${baseUrl}/${eventName}`,
+    deliveries: evts.length,
+    lastFired: evts[0]?.receivedAt ?? null,
+    events: evts,
+  }));
+}
+
+/* ─── Signature Config Section ─── */
+
+function SignatureConfig({ serverId }: { readonly serverId: string }) {
+  const { data: config, isLoading } = useWebhookConfig(serverId);
+  const setConfig = useSetWebhookConfig();
+  const clearConfig = useClearWebhookConfig();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [provider, setProvider] = useState("generic");
+  const [secret, setSecret] = useState("");
+  const [showSecret, setShowSecret] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await setConfig.mutateAsync({ serverId, provider, secret });
+      setDialogOpen(false);
+      setSecret("");
+      setShowSecret(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save webhook config");
+    }
+  };
+
+  const handleRemove = async () => {
+    try {
+      await clearConfig.mutateAsync(serverId);
+    } catch {
+      // Error handled by mutation state
+    }
+  };
+
+  if (isLoading) {
+    return <Skeleton className="h-20 rounded-lg" />;
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="border-b border-border px-4 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Shield className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium">Signature Validation</span>
+        </div>
+        {config?.configured ? (
+          <Badge variant="secondary" className="text-[10px] gap-1">
+            <ShieldCheck className="h-3 w-3 text-emerald-500" />
+            {config.provider}
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-[10px] gap-1 text-amber-500 border-amber-500/30">
+            <AlertTriangle className="h-3 w-3" />
+            Not configured
+          </Badge>
+        )}
+      </div>
+      <div className="p-4 space-y-3">
+        {config?.configured ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Incoming webhooks are verified using <strong>{config.provider}</strong> HMAC signature validation.
+              Only requests with a valid signature will be accepted.
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-xs"
+                onClick={() => {
+                  setProvider(config.provider ?? "generic");
+                  setSecret("");
+                  setDialogOpen(true);
+                }}
+              >
+                Rotate secret
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-xs text-destructive hover:text-destructive"
+                onClick={handleRemove}
+                disabled={clearConfig.isPending}
+              >
+                {clearConfig.isPending ? (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                ) : (
+                  <ShieldOff className="mr-1 h-3 w-3" />
+                )}
+                Remove
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="rounded-md bg-amber-500/5 border border-amber-500/20 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
+              Webhook signature validation is not configured. All incoming requests will be rejected.
+              Configure a signing secret to start receiving webhooks.
+            </div>
+            <Button
+              size="sm"
+              className="text-xs bg-violet-600 hover:bg-violet-700 text-white"
+              onClick={() => {
+                setProvider("generic");
+                setSecret("");
+                setError(null);
+                setDialogOpen(true);
+              }}
+            >
+              <ShieldCheck className="mr-1.5 h-3.5 w-3.5" />
+              Configure signing secret
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* Configure / Rotate dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {config?.configured ? "Rotate Webhook Secret" : "Configure Webhook Signing"}
+            </DialogTitle>
+            <DialogDescription>
+              Enter the signing secret from your webhook provider. This secret is encrypted at rest
+              and used to verify incoming request signatures.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-4 mt-2">
+            {/* Provider selector */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">Provider</label>
+              <div className="grid grid-cols-2 gap-2">
+                {PROVIDERS.map((p) => (
+                  <button
+                    key={p.value}
+                    type="button"
+                    onClick={() => setProvider(p.value)}
+                    className={`rounded-md border px-3 py-2 text-xs font-medium transition-colors ${
+                      provider === p.value
+                        ? "border-violet-500 bg-violet-500/10 text-violet-600 dark:text-violet-400"
+                        : "border-border bg-background text-muted-foreground hover:bg-muted/50"
+                    }`}
+                  >
+                    {p.label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-[10px] text-muted-foreground">
+                Validates via <code className="rounded bg-muted px-1 py-0.5 font-mono">
+                  {PROVIDERS.find((p) => p.value === provider)?.header}
+                </code> header
+              </p>
+            </div>
+
+            {/* Secret input */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">Signing secret</label>
+              <div className="relative">
+                <Input
+                  type={showSecret ? "text" : "password"}
+                  placeholder="whsec_..."
+                  value={secret}
+                  onChange={(e) => setSecret(e.target.value)}
+                  className="pr-10 font-mono text-xs"
+                  autoComplete="off"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowSecret((prev) => !prev)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  {showSecret ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                {error}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                size="sm"
+                className="bg-violet-600 hover:bg-violet-700 text-white"
+                disabled={!secret || secret.length < 8 || setConfig.isPending}
+              >
+                {setConfig.isPending && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                {config?.configured ? "Rotate" : "Save"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+/* ─── Event Components ─── */
 
 function EventRow({ event }: { readonly event: WebhookEvent }) {
   const [expanded, setExpanded] = useState(false);
@@ -56,6 +334,73 @@ function EventRow({ event }: { readonly event: WebhookEvent }) {
   );
 }
 
+function WebhookCard({
+  webhook,
+}: {
+  readonly webhook: {
+    readonly eventName: string;
+    readonly url: string;
+    readonly deliveries: number;
+    readonly lastFired: string | null;
+    readonly events: readonly WebhookEvent[];
+  };
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      {/* Card header */}
+      <div className="flex items-start gap-3 p-4">
+        <StatusDot variant="online" className="mt-1.5" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <code className="truncate font-mono text-sm font-medium">{webhook.url}</code>
+            <CopyButton value={webhook.url} className="h-6 w-6 shrink-0" />
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            <Badge variant="secondary" className="font-mono text-[10px] px-1.5 py-0">
+              {webhook.eventName}
+            </Badge>
+          </div>
+          <div className="mt-2 flex items-center gap-4 text-xs text-muted-foreground">
+            <span className="tabular-nums">{webhook.deliveries} deliveries</span>
+            {webhook.lastFired && (
+              <span>Last fired {timeAgo(webhook.lastFired)}</span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            <Play className="mr-1 h-3 w-3" />
+            {expanded ? "Hide" : "Events"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Expanded event log */}
+      {expanded && webhook.events.length > 0 && (
+        <div className="border-t border-border">
+          {webhook.events.slice(0, 10).map((event) => (
+            <EventRow key={event.id} event={event} />
+          ))}
+          {webhook.events.length > 10 && (
+            <div className="px-4 py-2 text-center text-xs text-muted-foreground">
+              +{webhook.events.length - 10} more events
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Page ─── */
+
 export default function WebhooksPage({
   params,
 }: {
@@ -67,24 +412,38 @@ export default function WebhooksPage({
 
   if (serverLoading) {
     return (
-      <div className="space-y-4">
-        <Skeleton className="h-6 w-48" />
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-10 w-36" />
+        </div>
         <Skeleton className="h-24 w-full rounded-lg" />
-        <Skeleton className="h-64 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
       </div>
     );
   }
 
   if (!server) return null;
 
-  const webhookUrl = `https://${PLATFORM_DOMAIN}/webhooks/${server.slug}/<event-name>`;
+  const webhookBaseUrl = `https://${PLATFORM_DOMAIN}/webhooks/${server.slug}`;
+  const webhookUrl = `${webhookBaseUrl}/<event-name>`;
+  const webhooks = events ? deriveWebhooks(events, webhookBaseUrl) : [];
 
   return (
     <div className="space-y-6">
-      <h1 className="text-lg font-semibold tracking-tight">Webhooks</h1>
+      {/* Header */}
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">Webhooks</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Receive real-time event notifications for {server.name}
+        </p>
+      </div>
+
+      {/* Signature validation config */}
+      <SignatureConfig serverId={id} />
 
       {/* Webhook endpoint URL */}
-      <div className="rounded-lg border border-border">
+      <div className="rounded-lg border border-border bg-card">
         <div className="border-b border-border px-4 py-3">
           <span className="text-sm font-medium">Webhook Endpoint</span>
         </div>
@@ -99,46 +458,40 @@ export default function WebhooksPage({
             </code>
             <CopyButton value={webhookUrl} className="h-7 w-7 shrink-0" />
           </div>
-          <div className="rounded-md bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-            Signature validation is supported for Stripe, GitHub, and Slack webhooks.
-            Events are stored for 24 hours and available as MCP resources.
-          </div>
         </div>
       </div>
 
-      {/* Event log */}
-      <div>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-medium">Recent Events</h2>
-          {events && events.length > 0 && (
+      {/* Webhook cards */}
+      {eventsError ? (
+        <div className="rounded-lg border border-destructive/30 p-6 text-center">
+          <p className="text-sm text-destructive">Failed to load webhook events. Please try again.</p>
+        </div>
+      ) : eventsLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-32 rounded-lg" />
+          <Skeleton className="h-32 rounded-lg" />
+        </div>
+      ) : webhooks.length > 0 ? (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-medium">Active Webhooks</h2>
             <span className="text-xs tabular-nums text-muted-foreground">
-              {events.length} event{events.length !== 1 ? "s" : ""}
+              {events?.length ?? 0} total events
             </span>
-          )}
+          </div>
+          {webhooks.map((wh) => (
+            <WebhookCard key={wh.eventName} webhook={wh} />
+          ))}
         </div>
-
-        {eventsError ? (
-          <div className="rounded-lg border border-destructive/30 p-6 text-center">
-            <p className="text-sm text-destructive">Failed to load webhook events. Please try again.</p>
-          </div>
-        ) : eventsLoading ? (
-          <Skeleton className="h-64 rounded-lg" />
-        ) : events && events.length > 0 ? (
-          <div className="rounded-lg border border-border">
-            {events.map((event) => (
-              <EventRow key={event.id} event={event} />
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-lg border border-border p-12">
-            <EmptyState
-              icon={Webhook}
-              title="No webhook events yet"
-              description="Events will appear here once your webhook endpoint receives its first request."
-            />
-          </div>
-        )}
-      </div>
+      ) : (
+        <div className="rounded-lg border border-border p-12">
+          <EmptyState
+            icon={Webhook}
+            title="No webhook events yet"
+            description="Events will appear here once your webhook endpoint receives its first request."
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/lib/db/migrations/0019_webhook_secrets.sql
+++ b/apps/web/lib/db/migrations/0019_webhook_secrets.sql
@@ -1,0 +1,16 @@
+-- Migration: 0019_webhook_secrets
+-- Adds per-server webhook signature validation fields.
+-- webhook_provider: identifies which SignatureValidator to use (stripe, github, slack, generic).
+-- encrypted_webhook_secret: AES-encrypted HMAC secret, decrypted at runtime.
+-- Both must be set together (enforced by CHECK constraint).
+
+ALTER TABLE mcp_servers
+  ADD COLUMN webhook_provider text,
+  ADD COLUMN encrypted_webhook_secret text;
+
+ALTER TABLE mcp_servers
+  ADD CONSTRAINT chk_webhook_secret_pair
+    CHECK (
+      (webhook_provider IS NULL AND encrypted_webhook_secret IS NULL)
+      OR (webhook_provider IS NOT NULL AND encrypted_webhook_secret IS NOT NULL)
+    );

--- a/apps/web/lib/db/repositories/server.repository.ts
+++ b/apps/web/lib/db/repositories/server.repository.ts
@@ -169,6 +169,45 @@ export class ServerRepository extends BaseRepository<
     return this.freeze(rows[0]!);
   }
 
+  async setWebhookConfig(
+    userId: string,
+    id: string,
+    provider: string,
+    encryptedSecret: string,
+  ): Promise<McpServer> {
+    const rows = await this.db
+      .update(mcpServers)
+      .set({
+        webhookProvider: provider,
+        encryptedWebhookSecret: encryptedSecret,
+      })
+      .where(and(eq(mcpServers.id, id), eq(mcpServers.userId, userId)))
+      .returning();
+
+    if (rows.length === 0) {
+      throw new Error('Server not found or access denied');
+    }
+
+    return this.freeze(rows[0]!);
+  }
+
+  async clearWebhookConfig(userId: string, id: string): Promise<McpServer> {
+    const rows = await this.db
+      .update(mcpServers)
+      .set({
+        webhookProvider: null,
+        encryptedWebhookSecret: null,
+      })
+      .where(and(eq(mcpServers.id, id), eq(mcpServers.userId, userId)))
+      .returning();
+
+    if (rows.length === 0) {
+      throw new Error('Server not found or access denied');
+    }
+
+    return this.freeze(rows[0]!);
+  }
+
   async delete(userId: string, id: string): Promise<void> {
     const result = await this.db
       .delete(mcpServers)

--- a/apps/web/lib/db/schema/servers.ts
+++ b/apps/web/lib/db/schema/servers.ts
@@ -31,6 +31,8 @@ export const mcpServers = pgTable(
     domainVerificationToken: text('domain_verification_token'),
     tokenHash: text('token_hash'),
     workspaceId: uuid('workspace_id'),
+    webhookProvider: text('webhook_provider'),
+    encryptedWebhookSecret: text('encrypted_webhook_secret'),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },

--- a/apps/web/lib/hooks/index.ts
+++ b/apps/web/lib/hooks/index.ts
@@ -20,5 +20,7 @@ export { useProfiles, useCreateProfile, useUpdateProfile, useDeleteProfile } fro
 export type { AccessProfile } from "./use-profiles";
 export { useWebhookEvents } from "./use-webhook-events";
 export type { WebhookEvent } from "./use-webhook-events";
+export { useWebhookConfig, useSetWebhookConfig, useClearWebhookConfig } from "./use-webhook-config";
+export type { WebhookConfig } from "./use-webhook-config";
 export { useComposites, useComposite, useCreateComposite, useUpdateComposite, useDeleteComposite } from "./use-composites";
 export { useWorkspaces, useWorkspace, useCreateWorkspace, useUpdateWorkspace, useInviteMember, useRemoveMember } from "./use-workspaces";

--- a/apps/web/lib/hooks/use-logs.ts
+++ b/apps/web/lib/hooks/use-logs.ts
@@ -18,6 +18,9 @@ export function useLogs(
     readonly from?: string;
     readonly to?: string;
   },
+  options?: {
+    readonly refetchInterval?: number | false;
+  },
 ) {
   return useInfiniteQuery({
     queryKey: ["logs", serverId, filters],
@@ -35,5 +38,7 @@ export function useLogs(
       lastPage.hasMore ? (lastPage.cursor ?? undefined) : undefined,
     staleTime: 10_000,
     enabled: !!serverId,
+    refetchInterval: options?.refetchInterval,
+    refetchIntervalInBackground: false,
   });
 }

--- a/apps/web/lib/hooks/use-runtime-health.ts
+++ b/apps/web/lib/hooks/use-runtime-health.ts
@@ -6,7 +6,7 @@ const RUNTIME_BASE_URL = typeof window !== "undefined"
   ? (process.env.NEXT_PUBLIC_RUNTIME_URL || "http://localhost:3001")
   : "http://localhost:3001";
 const RUNTIME_HEALTH_URL = `${RUNTIME_BASE_URL}/health`;
-const POLL_INTERVAL_MS = 10_000;
+const POLL_INTERVAL_MS = 30_000;
 
 interface RuntimeHealthResult {
   readonly isOnline: boolean;
@@ -28,6 +28,7 @@ export function useRuntimeHealth(): RuntimeHealthResult {
     queryKey: ["runtime-health"],
     queryFn: fetchRuntimeHealth,
     refetchInterval: POLL_INTERVAL_MS,
+    refetchIntervalInBackground: false,
     staleTime: POLL_INTERVAL_MS,
     retry: false,
   });

--- a/apps/web/lib/hooks/use-webhook-config.ts
+++ b/apps/web/lib/hooks/use-webhook-config.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api-client";
+
+export interface WebhookConfig {
+  readonly configured: boolean;
+  readonly provider: string | null;
+}
+
+export function useWebhookConfig(serverId: string) {
+  return useQuery({
+    queryKey: ["webhook-config", serverId],
+    queryFn: () => api.get<WebhookConfig>(`/servers/${serverId}/webhook-config`),
+    enabled: !!serverId,
+  });
+}
+
+export function useSetWebhookConfig() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      serverId,
+      provider,
+      secret,
+    }: {
+      readonly serverId: string;
+      readonly provider: string;
+      readonly secret: string;
+    }) =>
+      api.post<{ provider: string; secretWarning: string }>(
+        `/servers/${serverId}/webhook-config`,
+        { provider, secret },
+      ),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["webhook-config", variables.serverId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["servers", variables.serverId],
+      });
+    },
+  });
+}
+
+export function useClearWebhookConfig() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (serverId: string) =>
+      api.delete<{ cleared: boolean }>(`/servers/${serverId}/webhook-config`),
+    onSuccess: (_data, serverId) => {
+      queryClient.invalidateQueries({
+        queryKey: ["webhook-config", serverId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["servers", serverId],
+      });
+    },
+  });
+}

--- a/apps/web/lib/hooks/use-webhook-events.ts
+++ b/apps/web/lib/hooks/use-webhook-events.ts
@@ -15,6 +15,8 @@ export function useWebhookEvents(serverId: string) {
     queryKey: ["webhook-events", serverId],
     queryFn: () => api.get<WebhookEvent[]>(`/servers/${serverId}/webhook-events`),
     enabled: !!serverId,
-    refetchInterval: 10_000,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+    staleTime: 25_000,
   });
 }

--- a/packages/types/src/server.ts
+++ b/packages/types/src/server.ts
@@ -18,9 +18,13 @@ export interface McpServer {
   readonly customDomain: string | null;
   readonly domainVerifiedAt: Date | null;
   readonly tokenHash: string | null;
+  /** Webhook signature provider (stripe, github, slack, generic). Null = not configured. */
+  readonly webhookProvider: string | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
+
+export type WebhookProvider = 'stripe' | 'github' | 'slack' | 'generic';
 
 export interface ServerTokenResponse {
   readonly token: string;


### PR DESCRIPTION
## Summary

Fixes [GHSA-x82h-9r8v-m672](https://github.com/Work90210/APIFold/security/advisories/GHSA-x82h-9r8v-m672) — unauthenticated webhook event injection (CWE-306, CVSS 5.3).

### Security fix (commit 1)

- **Fail-closed webhook receiver**: requests are now rejected with `401` when no `SignatureValidator` is configured for the target server, instead of silently accepting unauthenticated payloads
- **Per-server webhook secrets**: adds `webhook_provider` and `encrypted_webhook_secret` columns to `mcp_servers` (migration 0019) with a CHECK constraint ensuring both are set together
- **Runtime wiring**: loads webhook config into `L0ServerMeta`, builds `SignatureValidator` instances at startup via `createValidatorForProvider`, and rebuilds on server changes via `onServerChange` callback in `RedisSubscriber` and `FallbackPoller`
- **`validators` is now required** on `WebhookReceiverDeps` — TypeScript prevents the original "forgot to pass validators" bug from recurring

### Webhook secret management UI + API (commit 2)

- `POST/GET/DELETE /api/servers/:id/webhook-config` for managing provider + AES-256-GCM encrypted secret
- Dashboard webhook page with signature config section: provider selector (Stripe, GitHub, Slack, Generic HMAC), secret input with visibility toggle, rotate, and remove actions
- `ServerRepository.setWebhookConfig` / `clearWebhookConfig` methods
- React Query hooks: `useWebhookConfig`, `useSetWebhookConfig`, `useClearWebhookConfig`
- `webhookProvider` added to `McpServer` type

### Root cause

`createWebhookRouter` was called in `server.ts:188` without a `validators` map. The receiver used optional chaining (`validators?.get(server.id)`) which returned `undefined`, causing the entire signature-validation block to be skipped. Attacker-controlled payloads were written to Redis and `webhook_events` and served as trusted state to MCP clients.

## Test plan

- [x] Webhook receiver rejects unauthenticated requests with 401
- [x] Webhook receiver accepts properly signed requests (HMAC-SHA256)
- [x] All 181 previously-passing runtime tests continue to pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`) for both runtime and web
- [ ] Run migration 0019 against staging DB
- [ ] Configure a webhook secret via the new UI and verify end-to-end delivery
- [ ] Verify rotate and remove actions work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook signature validation configuration. Users can now select a webhook provider (Stripe, GitHub, Slack, or generic) and configure signing secrets for enhanced security.
  * Enhanced logs page with live mode, real-time filtering by status and keywords, detail panels for inspecting requests and responses, and improved layout for better visibility.
  * Redesigned webhooks page with webhook endpoint cards grouped by event type, delivery statistics, and integrated signature configuration management.

* **Improvements**
  * Webhook validation now enforces stricter security checks with fail-closed behavior.
  * Updated polling intervals for better performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->